### PR TITLE
修改类属性默认值的获取方式

### DIFF
--- a/src/Swagger/SwaggerComponents.php
+++ b/src/Swagger/SwaggerComponents.php
@@ -77,13 +77,12 @@ class SwaggerComponents
                 $requiredArr[] = $fieldName;
             }
             $property->example = $apiModelProperty->example;
-            try {
-                $obj = make($className);
-                if ($reflectionProperty->isPublic() && $reflectionProperty->isInitialized($obj)) {
-                    $property->default = $reflectionProperty->getValue($obj);
-                }
-            } catch (\Throwable) {
+
+            $classVars = get_class_vars($className);
+            if(isset($classVars[$fieldName])){
+                $property->default = $classVars[$fieldName];
             }
+
 
             // swagger 类型
             $swaggerType = $this->common->getSwaggerType($propertyManager->phpSimpleType);


### PR DESCRIPTION
代码`$obj = make($className);`  会出现一个这样的问题：
class 有不为空参数的构造方法，会报错，如下：
```
class A{
    public function  __construct($param){}
}
```
由于没有传参数，所以会报错。因为make函数只适用于依赖注入，并没有对初始化传参功能。

报错场景：
```
#[PostMapping(path: "register")]
 public function register(): OkVo
```
```
class OkVo 
{
    public function __construct($message)
    {
    }
}
```
上面代码的中 OkVo 需要构造函数传参，但make函数给不了对应的参数。

针对以下场景，本PR使用 get_class_vars 函数，去避免实例化参数这一步，来获取类属性的默认值。
希望作者采纳本PR